### PR TITLE
Update docker_install.md

### DIFF
--- a/docs/WeBASE-Install/docker_install.md
+++ b/docs/WeBASE-Install/docker_install.md
@@ -643,8 +643,8 @@ python版本要求使用python3.x, 推荐使用python3.6及以上版本
 
 #### ① CentOS安装MariaDB
 
-此处以**CentOS 7(x86_64)**安装**MariaDB 10.2**为例。*MariaDB*数据库是 MySQL 的一个分支，主要由开源社区在维护，采用 GPL 授权许可。*MariaDB*完全兼容 MySQL，包括API和命令行。MariaDB 10.2版本对应Mysql 5.7。其他安装方式请参考[MySQL官网](https://dev.mysql.com/downloads/mysql/)。
-- CentOS 7 默认MariaDB为5.5版本，安装10.2版本需要按下文进行10.2版本的配置。
+此处以**CentOS 7(x86_64)**安装**MariaDB 10.3**为例。*MariaDB*数据库是 MySQL 的一个分支，主要由开源社区在维护，采用 GPL 授权许可。*MariaDB*完全兼容 MySQL，包括API和命令行。MariaDB 10.3版本对应Mysql 5.7。其他安装方式请参考[MySQL官网](https://dev.mysql.com/downloads/mysql/)。
+- CentOS 7 默认MariaDB为5.5版本，安装10.3版本需要按下文进行10.3版本的配置。
 - 若使用CentOS 8则直接使用`sudo yum install -y mariadb*`即可安装MariaDB 10.3，并跳到下文的 *启停* 章节即可。
 
 使用`vi`或`vim`创建新文件`/etc/yum.repos.d/mariadb.repo`，并写入下文的文件内容（参考[MariaDB中科大镜像源修改](http://mirrors.ustc.edu.cn/help/mariadb.html)进行配置）
@@ -656,11 +656,11 @@ sudo vi /etc/yum.repos.d/mariadb.repo
 
 - 文件内容，此处使用的是中科大镜像源
 ```Bash
-# MariaDB 10.2 CentOS repository list - created 2021-07-12 07:37 UTC
+# MariaDB 10.3 CentOS repository list - created 2021-07-12 07:37 UTC
 # http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = https://mirrors.ustc.edu.cn/mariadb/yum/10.2/centos7-amd64
+baseurl = https://mirrors.ustc.edu.cn/mariadb/yum/10.3/centos7-amd64
 gpgkey=https://mirrors.ustc.edu.cn/mariadb/yum/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 ```
@@ -671,7 +671,7 @@ yum clean all
 yum makecache all
 ```
 
-- 安装`MariaDB 10.2`
+- 安装`MariaDB 10.3
 - 如果已存在使用`sudo yum install -y mariadb*`命令安装的MariaDB，其版本默认为5.5版本，对应Mysql版本为5.5。新版本MariaDB无法兼容升级，需要先**卸载旧版本**的MariaDB，卸载前需要**备份**数据库内容，卸载命令可参考`yum remove mariadb`
 ```
 sudo yum install MariaDB-server MariaDB-client -y


### PR DESCRIPTION
mariadb 10.2版本在镜像仓库中找不到，10.3的版本和10.2完全兼容