### PR TITLE
update WeBASE-Front/index.md

### DIFF
--- a/docs/WeBASE-Front/install.md
+++ b/docs/WeBASE-Front/install.md
@@ -147,6 +147,6 @@ http://{deployIP}:{frontPort}/WeBASE-Front
 
 ```
 前置服务全量日志：tail -f log/WeBASE-Front.log
-前置服务错误日志：tail -f log/WeBASE-Front.log
+前置服务错误日志：tail -f log/WeBASE-Front-error.log
 web3连接日志：tail -f log/web3sdk.log
 ```


### PR DESCRIPTION
https://webasedoc.readthedocs.io/zh_CN/latest/docs/WeBASE-Front/install.html#id9
这里的`前置服务错误日志：tail -f log/WeBASE-Front.log`应改为`前置服务错误日志：tail -f log/WeBASE-Front-error.log`