### PR TITLE
ubuntu下jdk版本导致一键部署前端启动失败问题.md

### DIFF
--- a/docs/WeBASE/install.md
+++ b/docs/WeBASE/install.md
@@ -542,8 +542,8 @@ java -version
 <span id="ubuntujava"></span>
 
 ```
-  # 安装默认Java版本(Java 8或以上)
-  sudo apt install -y default-jdk
+  # 安装oracle Java版本(Java 8或以上，默认的openjdk无法启动一键部署)
+  sudo apt-get install oracle-java8-installer 
   # 查询Java版本
   java -version
 ```


### PR DESCRIPTION
官方文档下ubuntu的默认安装指令安装的是openjdk-1.8与环境要求的oraclejdk-1.8以上版本不符合，一键部署时会出现wabase前端启动失败的问题 需改用下载oraclejdk的下载命令 不应使用默认的命令配置环境